### PR TITLE
2 Fixes for ProximityHider

### DIFF
--- a/src/lishid/orebfuscator/listeners/OrebfuscatorPlayerListener.java
+++ b/src/lishid/orebfuscator/listeners/OrebfuscatorPlayerListener.java
@@ -101,8 +101,9 @@ public class OrebfuscatorPlayerListener implements Listener
 	@EventHandler(priority = EventPriority.MONITOR)
 	public void onPlayerMove(PlayerMoveEvent event)
 	{
-		if(event.getTo().equals(event.getFrom()))
-			return;
+		if(event.getTo().equals(event.getFrom())) {
+		    return;
+		}
 		
     	if(OrebfuscatorConfig.getUseProximityHider())
     	{

--- a/src/lishid/orebfuscator/proximityhider/ProximityHider.java
+++ b/src/lishid/orebfuscator/proximityhider/ProximityHider.java
@@ -48,7 +48,10 @@ public class ProximityHider
                     {
                         Location loc1 = p.getLocation();
                         Location loc2 = (newPlayers.get(p));
-
+                        
+                        if(!loc1.getWorld().getName().equalsIgnoreCase(loc2.getWorld().getName()))
+                            continue;
+                        
                         if(loc1.getBlock().getLocation().distance(loc2.getBlock().getLocation()) < 0.9)
                         {
                             continue;


### PR DESCRIPTION
Basically just fixing the proximity hider by checking if the From and To locations are exact instead of checking whether the event was cancelled.

Then fixing a task exception where two different worlds in two different locations are being distance checked.
