### PR TITLE
Use distanceSquared instead of distance for proximity (hider)

### DIFF
--- a/src/com/lishid/orebfuscator/obfuscation/ProximityHider.java
+++ b/src/com/lishid/orebfuscator/obfuscation/ProximityHider.java
@@ -85,6 +85,8 @@ public class ProximityHider extends Thread implements Runnable
                     newPlayers.putAll(playersToCheck);
                     playersToCheck.clear();
                 }
+				
+				int distanceSquared = OrebfuscatorConfig.getProximityHiderDistance();
                 
                 for (Player p : newPlayers.keySet())
                 {
@@ -138,7 +140,7 @@ public class ProximityHider extends Thread implements Runnable
                             continue;
                         }
                         
-                        if (p.getLocation().distance(b.getLocation()) < OrebfuscatorConfig.getProximityHiderDistance())
+                        if (p.getLocation().distanceSquared(b.getLocation()) < distanceSquared)
                         {
                             removedBlocks.add(b);
                             


### PR DESCRIPTION
Using squared distance bypasses the usage of the squareroot function which offers some performance increase, not sure exactly how much but every little bit counts right?
