### PR TITLE
Only cancel tasks for Orebfuscator

### DIFF
--- a/src/main/java/com/lishid/orebfuscator/Orebfuscator.java
+++ b/src/main/java/com/lishid/orebfuscator/Orebfuscator.java
@@ -95,7 +95,7 @@ public class Orebfuscator extends JavaPlugin {
         ObfuscatedDataCache.clearCache();
         BlockHitManager.clearAll();
         ChunkProcessingThread.KillAll();
-        getServer().getScheduler().cancelAllTasks();
+        getServer().getScheduler().cancelTasks(this);
     }
 
     @Override


### PR DESCRIPTION
When Orebfuscator is disabled, it cancels ALL tasks for ALL plugins. This breaks all other plugins when orebfuscator is reloaded using PlugMan.
This pull request makes Orebfuscator only cancel tasks that it has scheduled for itself.