### PR TITLE
Fix Spigot anti-xray disabling

### DIFF
--- a/src/main/java/com/lishid/orebfuscator/internal/MinecraftInternals.java
+++ b/src/main/java/com/lishid/orebfuscator/internal/MinecraftInternals.java
@@ -50,7 +50,7 @@ public class MinecraftInternals {
     public static void tryDisableSpigotAntiXray(org.bukkit.World world) {
         try {
             World mcworld = ((CraftWorld) world).getHandle();
-            Object spigotWorldConfig = ReflectionHelper.getPrivateField(mcworld, "spigotConfig");
+            Object spigotWorldConfig = World.class.getField("spigotConfig").get(mcworld);
             ReflectionHelper.setPrivateField(spigotWorldConfig, "antiXray", false);
         } catch (Exception e) {
             Orebfuscator.log(e);


### PR DESCRIPTION
The current code causes this error on enable:

[14:51:42 ERROR]: [OFC] java.lang.NoSuchFieldException: spigotConfig
[14:51:42 WARN]: java.lang.NoSuchFieldException: spigotConfig
[14:51:42 WARN]:        at java.lang.Class.getDeclaredField(Class.java:2062)
[14:51:42 WARN]:        at com.lishid.orebfuscator.utils.ReflectionHelper.getPrivateField(ReflectionHelper.java:27)
[14:51:42 WARN]:        at com.lishid.orebfuscator.utils.ReflectionHelper.getPrivateField(ReflectionHelper.java:38)
[14:51:42 WARN]:        at com.lishid.orebfuscator.internal.MinecraftInternals.tryDisableSpigotAntiXray(MinecraftInternals.java:53)

This pull request fixes that error. The world handle is not a direct instance of World, so attempting to get a declared field from a different class will fail. spigotConfig is a public field, anyway.