### PR TITLE
Fix for 1.8.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <groupId>com.lishid</groupId>
   <artifactId>orebfuscator</artifactId>
   <packaging>jar</packaging>
-  <version>3.0.0</version>
+  <version>3.0.6</version>
   <name>Orebfuscator</name>
   <url>http://dev.bukkit.org/server-mods/orebfuscator/</url>
 
@@ -34,7 +34,7 @@
     <dependency>
       <groupId>org.bukkit</groupId>
       <artifactId>craftbukkit</artifactId>
-      <version>1.8-R0.1-SNAPSHOT</version>
+      <version>1.8.3-R0.1-SNAPSHOT</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/lishid/orebfuscator/OrebfuscatorConfig.java
+++ b/src/main/java/com/lishid/orebfuscator/OrebfuscatorConfig.java
@@ -121,6 +121,9 @@ public class OrebfuscatorConfig {
             if (i == org.bukkit.Material.TNT.getId()) {
                 TransparentBlocks[i] = false;
             }
+            if (i == org.bukkit.Material.AIR.getId()) {
+                TransparentBlocks[i] = true;
+            }
         }
         TransparentCached = true;
     }

--- a/src/main/java/com/lishid/orebfuscator/OrebfuscatorConfig.java
+++ b/src/main/java/com/lishid/orebfuscator/OrebfuscatorConfig.java
@@ -184,10 +184,10 @@ public class OrebfuscatorConfig {
         return retval.length() > 1 ? retval.substring(0, retval.length() - 2) : retval;
     }
 
-    public static byte getRandomBlock(int index, boolean alternate, World.Environment environment) {
+    public static int getRandomBlock(int index, boolean alternate, World.Environment environment) {
         if (environment == World.Environment.NETHER)
-            return (byte) (int) (NetherRandomBlocks[index]);
-        return (byte) (int) (alternate ? RandomBlocks2[index] : RandomBlocks[index]);
+            return (int) (NetherRandomBlocks[index]);
+        return (int) (alternate ? RandomBlocks2[index] : RandomBlocks[index]);
     }
 
     public static Integer[] getRandomBlocks(boolean alternate, World.Environment environment) {

--- a/src/main/java/com/lishid/orebfuscator/internal/MinecraftInternals.java
+++ b/src/main/java/com/lishid/orebfuscator/internal/MinecraftInternals.java
@@ -27,7 +27,7 @@ import org.bukkit.entity.Player;
 
 public class MinecraftInternals {
     public static boolean isBlockTransparent(int id) {
-        return !Block.getById(id).s();
+        return Block.getById(id).s();
     }
 
     public static void updateBlockTileEntity(org.bukkit.block.Block block, Player player) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: Orebfuscator3
 main: com.lishid.orebfuscator.Orebfuscator
-version: 3.0.5
+version: 3.0.6
 author: lishid
 softdepend: [ProtocolLib]
 load: startup


### PR DESCRIPTION
In Minecraft 1.8.3 Block.getById(id).s() returns true if the block is transparent in 1.8.1 it returned false.