### PR TITLE
New method is U

### DIFF
--- a/src/main/java/com/lishid/orebfuscator/internal/MinecraftInternals.java
+++ b/src/main/java/com/lishid/orebfuscator/internal/MinecraftInternals.java
@@ -27,7 +27,7 @@ import org.bukkit.entity.Player;
 
 public class MinecraftInternals {
     public static boolean isBlockTransparent(int id) {
-        return Block.getById(id).s();
+        return Block.getById(id).u();
     }
 
     public static void updateBlockTileEntity(org.bukkit.block.Block block, Player player) {


### PR DESCRIPTION
The new method is u() for 1.8.3

Should consider this method does not return all the transparents blocs, I use a custom block list to be sure.