### PR TITLE
Also use spigot repo to get spigot api jars

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,10 @@
       <id>dmulloy2-repo</id>
       <url>http://repo.dmulloy2.net/content/groups/public/</url>
     </repository>
+    <repository>
+      <id>spigot-repo</id>
+      <url>https://hub.spigotmc.org/nexus/content/repositories/snapshots/</url>
+     </repository>
   </repositories>
 
   <modules>


### PR DESCRIPTION
Couldn't compile for 1.10 since dmulloy2's maven repo is missing a pom.

```
[WARNING] The POM for org.spigotmc:spigot-api:jar:1.10-R0.1-SNAPSHOT is missing,   no dependency information available