### PR TITLE
Mark farmland as transparent

### DIFF
--- a/Plugin/src/main/resources/resources/transparent_blocks.txt
+++ b/Plugin/src/main/resources/resources/transparent_blocks.txt
@@ -58,7 +58,7 @@
 57:false //minecraft:diamond_block
 58:false //minecraft:crafting_table
 59:true //minecraft:wheat
-60:false //minecraft:farmland
+60:true //minecraft:farmland
 61:false //minecraft:furnace
 62:false //minecraft:lit_furnace
 63:true //minecraft:standing_sign


### PR DESCRIPTION
Farmland is only 15/16 of a block high and allows you to see adjacent blocks. It must be marked transparent to avoid problems with obfuscated blocks being visible.