### PR TITLE
pre-1.13 support

### DIFF
--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -4,7 +4,7 @@
 
   <groupId>com.lishid</groupId>
   <artifactId>orebfuscator</artifactId>
-  <version>4.3.3-SNAPSHOT</version>
+  <version>4.4.0-SNAPSHOT</version>
   <packaging>jar</packaging>
 
   <name>Orebfuscator4</name>
@@ -73,7 +73,7 @@
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
-    <dependency>
+  <dependency>
       <groupId>com.lishid</groupId>
       <artifactId>orebfuscator-v1_11_R1</artifactId>
       <version>v1_11_R1</version>
@@ -81,7 +81,7 @@
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
-    <dependency>
+  <dependency>
       <groupId>com.lishid</groupId>
       <artifactId>orebfuscator-v1_12_R1</artifactId>
       <version>v1_12_R1</version>
@@ -89,7 +89,15 @@
       <scope>compile</scope>
       <optional>true</optional>
     </dependency>
-  </dependencies>
+  <dependency>
+    <groupId>com.lishid</groupId>
+    <artifactId>orebfuscator-v1_13_R1</artifactId>
+    <version>v1_13_R1</version>
+    <type>jar</type>
+    <scope>compile</scope>
+    <optional>true</optional>
+  </dependency>
+</dependencies>
 
   <build>
     <directory>../target</directory>

--- a/Plugin/src/main/java/com/lishid/orebfuscator/Orebfuscator.java
+++ b/Plugin/src/main/java/com/lishid/orebfuscator/Orebfuscator.java
@@ -142,7 +142,10 @@ public class Orebfuscator extends JavaPlugin {
 
         String serverVersion = org.bukkit.Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
 
-        if(serverVersion.equals("v1_12_R1")) {
+        if(serverVersion.equals("v1_13_R1")) {
+            return new com.lishid.orebfuscator.nms.V1_13_R1.NmsManager();
+        }
+        else if(serverVersion.equals("v1_12_R1")) {
             return new com.lishid.orebfuscator.nms.v1_12_R1.NmsManager();
         }
         else if(serverVersion.equals("v1_11_R1")) {

--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
     <module>v1_10_R1</module>
     <module>v1_11_R1</module>
     <module>v1_12_R1</module>
+    <module>v1_13_R1</module>
     <module>Plugin</module>
   </modules>
 

--- a/v1_13_R1/pom.xml
+++ b/v1_13_R1/pom.xml
@@ -1,0 +1,46 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>com.lishid</groupId>
+    <artifactId>orebfuscator-v1_13_R1</artifactId>
+    <version>v1_13_R1</version>
+    <packaging>jar</packaging>
+    <name>Orebfuscator4 v1_13_R1</name>
+
+    <parent>
+        <groupId>com.lishid.parent</groupId>
+        <artifactId>orebfuscator-parent</artifactId>
+        <version>parent</version>
+    </parent>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>3.1</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.spigotmc</groupId>
+            <artifactId>spigot</artifactId>
+            <version>1.13-R0.1-SNAPSHOT</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>com.lishid</groupId>
+            <artifactId>orebfuscator-api</artifactId>
+            <version>API</version>
+            <type>jar</type>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/v1_13_R1/src/main/java/com/lishid/orebfuscator/nms/v1_13_R1/BlockInfo.java
+++ b/v1_13_R1/src/main/java/com/lishid/orebfuscator/nms/v1_13_R1/BlockInfo.java
@@ -1,0 +1,60 @@
+package com.lishid.orebfuscator.nms.v1_13_R1;
+
+import com.lishid.orebfuscator.nms.IBlockInfo;
+import net.minecraft.server.v1_13_R1.Block;
+import net.minecraft.server.v1_13_R1.IBlockData;
+
+public class BlockInfo implements IBlockInfo {
+    private int x;
+    private int y;
+    private int z;
+    private IBlockData blockData;
+
+    public BlockInfo(int x, int y, int z, IBlockData blockData) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.blockData = blockData;
+    }
+
+    public int getX() {
+        return this.x;
+    }
+
+    public int getY() {
+        return this.y;
+    }
+
+    public int getZ() {
+        return this.z;
+    }
+
+    public int getTypeId() {
+        return Block.getCombinedId(this.blockData);
+    }
+
+    public IBlockData getBlockData() {
+        return this.blockData;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == null || !(other instanceof BlockInfo)) {
+            return false;
+        }
+        BlockInfo object = (BlockInfo) other;
+
+        return this.x == object.x && this.y == object.y && this.z == object.z;
+    }
+
+    @Override
+    public int hashCode() {
+        return this.x ^ this.y ^ this.z;
+    }
+
+    @Override
+    public String toString() {
+        return this.x + " " + this.y + " " + this.z;
+    }
+}
+

--- a/v1_13_R1/src/main/java/com/lishid/orebfuscator/nms/v1_13_R1/ChunkCache.java
+++ b/v1_13_R1/src/main/java/com/lishid/orebfuscator/nms/v1_13_R1/ChunkCache.java
@@ -1,0 +1,78 @@
+package com.lishid.orebfuscator.nms.v1_13_R1;
+
+import com.lishid.orebfuscator.nms.IChunkCache;
+import net.minecraft.server.v1_13_R1.RegionFile;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.util.HashMap;
+
+public class ChunkCache implements IChunkCache {
+    private static final HashMap<File, RegionFile> cachedRegionFiles = new HashMap<File, RegionFile>();
+
+    private int maxLoadedCacheFiles;
+
+    public ChunkCache(int maxLoadedCacheFiles) {
+        this.maxLoadedCacheFiles = maxLoadedCacheFiles;
+    }
+
+    public DataInputStream getInputStream(File folder, int x, int z) {
+        RegionFile regionFile = getRegionFile(folder, x, z);
+        return regionFile.a(x & 0x1F, z & 0x1F);
+    }
+
+    public DataOutputStream getOutputStream(File folder, int x, int z) {
+        RegionFile regionFile = getRegionFile(folder, x, z);
+        return regionFile.c(x & 0x1F, z & 0x1F);
+    }
+
+    public void closeCacheFiles() {
+        closeCacheFilesInternal();
+    }
+
+    private synchronized RegionFile getRegionFile(File folder, int x, int z) {
+        File path = new File(folder, "region");
+        File file = new File(path, "r." + (x >> 5) + "." + (z >> 5) + ".mcr");
+        try {
+            RegionFile regionFile = cachedRegionFiles.get(file);
+            if (regionFile != null) {
+                return regionFile;
+            }
+
+            if (!path.exists()) {
+                path.mkdirs();
+            }
+
+            if (cachedRegionFiles.size() >= this.maxLoadedCacheFiles) {
+                closeCacheFiles();
+            }
+
+            regionFile = new RegionFile(file);
+            cachedRegionFiles.put(file, regionFile);
+
+            return regionFile;
+        }
+        catch (Exception e) {
+            try {
+                file.delete();
+            }
+            catch (Exception e2) {
+            }
+        }
+        return null;
+    }
+
+    private synchronized void closeCacheFilesInternal() {
+        for (RegionFile regionFile : cachedRegionFiles.values()) {
+            try {
+                if (regionFile != null)
+                    regionFile.c();
+            }
+            catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+        cachedRegionFiles.clear();
+    }
+}

--- a/v1_13_R1/src/main/java/com/lishid/orebfuscator/nms/v1_13_R1/ChunkManager.java
+++ b/v1_13_R1/src/main/java/com/lishid/orebfuscator/nms/v1_13_R1/ChunkManager.java
@@ -1,0 +1,32 @@
+package com.lishid.orebfuscator.nms.v1_13_R1;
+
+import com.lishid.orebfuscator.nms.IChunkManager;
+import net.minecraft.server.v1_13_R1.*;
+import org.bukkit.entity.Player;
+
+import java.util.HashSet;
+
+public class ChunkManager implements IChunkManager {
+    private PlayerChunkMap chunkMap;
+
+    public ChunkManager(PlayerChunkMap chunkMap) {
+        this.chunkMap = chunkMap;
+    }
+
+    public boolean resendChunk(int chunkX, int chunkZ, HashSet<Player> affectedPlayers) {
+        if(!this.chunkMap.isChunkInUse(chunkX, chunkZ)) return true;
+
+        PlayerChunk playerChunk = this.chunkMap.getChunk(chunkX, chunkZ);
+
+        if(playerChunk == null || playerChunk.chunk == null || !playerChunk.chunk.isReady()) return false;
+
+        for(EntityPlayer player : playerChunk.c) {
+            player.playerConnection.sendPacket(new PacketPlayOutUnloadChunk(chunkX, chunkZ));
+            player.playerConnection.sendPacket(new PacketPlayOutMapChunk(playerChunk.chunk, 0xffff));
+
+            affectedPlayers.add(player.getBukkitEntity());
+        }
+
+        return true;
+    }
+}

--- a/v1_13_R1/src/main/java/com/lishid/orebfuscator/nms/v1_13_R1/NBT.java
+++ b/v1_13_R1/src/main/java/com/lishid/orebfuscator/nms/v1_13_R1/NBT.java
@@ -1,0 +1,67 @@
+package com.lishid.orebfuscator.nms.v1_13_R1;
+
+import com.lishid.orebfuscator.nms.INBT;
+
+import net.minecraft.server.v1_13_R1.NBTCompressedStreamTools;
+import net.minecraft.server.v1_13_R1.NBTTagCompound;
+
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.DataOutput;
+import java.io.IOException;
+
+public class NBT implements INBT {
+    NBTTagCompound nbt = new NBTTagCompound();
+
+    public void reset() {
+        nbt = new NBTTagCompound();
+    }
+
+    public void setInt(String tag, int value) {
+        nbt.setInt(tag, value);
+    }
+
+    public void setLong(String tag, long value) {
+        nbt.setLong(tag, value);
+    }
+
+    public void setBoolean(String tag, boolean value) {
+        nbt.setBoolean(tag, value);
+    }
+
+    public void setByteArray(String tag, byte[] value) {
+        nbt.setByteArray(tag, value);
+    }
+
+    public void setIntArray(String tag, int[] value) {
+        nbt.setIntArray(tag, value);
+    }
+
+    public int getInt(String tag) {
+        return nbt.getInt(tag);
+    }
+
+    public long getLong(String tag) {
+        return nbt.getLong(tag);
+    }
+
+    public boolean getBoolean(String tag) {
+        return nbt.getBoolean(tag);
+    }
+
+    public byte[] getByteArray(String tag) {
+        return nbt.getByteArray(tag);
+    }
+
+    public int[] getIntArray(String tag) {
+        return nbt.getIntArray(tag);
+    }
+
+    public void Read(DataInput stream) throws IOException {
+        nbt = NBTCompressedStreamTools.a((DataInputStream) stream);
+    }
+
+    public void Write(DataOutput stream) throws IOException {
+        NBTCompressedStreamTools.a(nbt, stream);
+    }
+}

--- a/v1_13_R1/src/main/java/com/lishid/orebfuscator/nms/v1_13_R1/NmsManager.java
+++ b/v1_13_R1/src/main/java/com/lishid/orebfuscator/nms/v1_13_R1/NmsManager.java
@@ -1,0 +1,128 @@
+package com.lishid.orebfuscator.nms.v1_13_R1;
+
+import com.lishid.orebfuscator.nms.*;
+import com.lishid.orebfuscator.types.BlockCoord;
+import com.lishid.orebfuscator.types.BlockState;
+
+import net.minecraft.server.v1_13_R1.*;
+
+import org.bukkit.World;
+import org.bukkit.craftbukkit.v1_13_R1.CraftWorld;
+import org.bukkit.craftbukkit.v1_13_R1.entity.CraftPlayer;
+import org.bukkit.craftbukkit.v1_13_R1.util.CraftChatMessage;
+import org.bukkit.entity.Player;
+
+public class NmsManager implements INmsManager {
+    private int maxLoadedCacheFiles;
+
+    private static IBlockData getBlockData(World world, int x, int y, int z) {
+        int chunkX = x >> 4;
+        int chunkZ = z >> 4;
+
+        WorldServer worldServer = ((CraftWorld)world).getHandle();
+        ChunkProviderServer chunkProviderServer = worldServer.getChunkProviderServer();
+
+        if(!chunkProviderServer.isLoaded(chunkX, chunkZ)) return null;
+
+        Chunk chunk = chunkProviderServer.getOrLoadChunkAt(chunkX, chunkZ);
+
+        return chunk.getBlockData(x, y, z);
+    }
+
+    @Override
+    public void setMaxLoadedCacheFiles(int value) { this.maxLoadedCacheFiles = value; }
+    @Override
+    public INBT createNBT() { return new NBT(); }
+
+    @Override
+    public IChunkCache createChunkCache() {
+        return new ChunkCache(this.maxLoadedCacheFiles);
+    }
+
+    @Override
+    public IChunkManager getChunkManager(World world) {
+        WorldServer worldServer = ((CraftWorld)world).getHandle();
+        PlayerChunkMap chunkMap = worldServer.getPlayerChunkMap();
+
+        return new ChunkManager(chunkMap);
+    }
+
+    @Override
+    public void updateBlockTileEntity(BlockCoord blockCoord, Player player) {
+        CraftWorld world = (CraftWorld)player.getWorld();
+        TileEntity tileEntity = world.getTileEntityAt(blockCoord.x, blockCoord.y, blockCoord.z);
+
+        if (tileEntity == null) {
+            return;
+        }
+
+        Packet<?> packet = tileEntity.getUpdatePacket();
+
+        if (packet != null) {
+            CraftPlayer player2 = (CraftPlayer)player;
+            player2.getHandle().playerConnection.sendPacket(packet);
+        }
+    }
+
+    @Override
+    public void notifyBlockChange(World world, IBlockInfo blockInfo) {
+        BlockPosition blockPosition = new BlockPosition(blockInfo.getX(), blockInfo.getY(), blockInfo.getZ());
+        IBlockData blockData = ((BlockInfo)blockInfo).getBlockData();
+
+        ((CraftWorld)world).getHandle().notify(blockPosition, blockData, blockData, 0);
+    }
+
+    @Override
+    public int getBlockLightLevel(World world, int x, int y, int z) {
+        return ((CraftWorld)world).getHandle().getLightLevel(new BlockPosition(x, y, z));
+    }
+
+    @Override
+    public IBlockInfo getBlockInfo(World world, int x, int y, int z) {
+        IBlockData blockData = getBlockData(world, x, y, z);
+
+        return blockData != null
+            ? new BlockInfo(x, y, z, blockData)
+            : null;
+    }
+
+    @Override
+    public BlockState getBlockState(World world, int x, int y, int z) {
+        IBlockData blockData = getBlockData(world, x, y, z);
+
+        if(blockData == null) return null;
+
+        Block block = blockData.getBlock();
+
+        BlockState blockState = new BlockState();
+        blockState.id = Block.getCombinedId(blockData);
+
+        // As far as I can tell toLegacyData doesn't exist in 1.13 yet.
+        // The original implementation gets a list of block states from blockData, and if empty returns 0,
+        // otherwise throws an exception.
+        //
+        // As far as I can tell BlockData only has a method to update state, and no method that returns
+        // states. So we grab block states from the block instance itself.
+        boolean hasEmptyState = block.getStates().d().isEmpty();
+        if (!hasEmptyState) {
+            throw new IllegalArgumentException("Don't know how to convert " + blockData + " back into data...");
+        }
+        blockState.meta = 0;
+
+        return blockState;
+    }
+
+    @Override
+    public int getBlockId(World world, int x, int y, int z) {
+        IBlockData blockData = getBlockData(world, x, y, z);
+
+        return blockData != null ? Block.getCombinedId(blockData): -1;
+    }
+
+    @Override
+    public String getTextFromChatComponent(String json) {
+        IChatBaseComponent component = IChatBaseComponent.ChatSerializer.a(json);
+
+        return CraftChatMessage.fromComponent(component);
+    }
+}


### PR DESCRIPTION
this commit adds in a module for 1.13 NMS. I haven't been able to look into the loading error mentioned in #180 , due to not getting a successful build of the actual: `Plugin` maven module.

At first I got:

```
[ERROR] Failed to execute goal on project orebfuscator: Could not resolve dependencies for project com.lishid:orebfuscator:jar:4.4.0-SNAPSHOT: Failed to collect dependencies at com.comphenix.protocol:ProtocolLib-API:jar:4.0.0: Failed to read artifact descriptor for com.comphenix.protocol:ProtocolLib-API:jar:4.0.0: Could not transfer artifact com.comphenix.protocol:ProtocolLib-API:pom:4.0.0 from/to techcable-repo (https://repo.techcable.net/content/groups/public/): Failed to transfer file: https://repo.techcable.net/content/groups/public/com/comphenix/protocol/ProtocolLib-API/4.0.0/ProtocolLib-API-4.0.0.pom. Return code is: 502 , ReasonPhrase:Bad Gateway. -> [Help 1]
```

Changing ProtocolLib to a newer version locally like: 4.2.1 that exists for sure results in:

```
[ERROR] Failed to execute goal on project orebfuscator: Could not resolve dependencies for project com.lishid:orebfuscator:jar:4.4.0-SNAPSHOT: Failed to collect dependencies at com.lishid:orebfuscator-api:jar:API: Failed to read artifact descriptor for com.lishid:orebfuscator-api:jar:API: Could not transfer artifact com.lishid:orebfuscator-api:pom:API from/to techcable-repo (https://repo.techcable.net/content/groups/public/): Failed to transfer file: https://repo.techcable.net/content/groups/public/com/lishid/orebfuscator-api/API/orebfuscator-api-API.pom. Return code is: 502 , ReasonPhrase:Bad Gateway. -> [Help 1]
```

Even after a: `mvn install` in the API directory.

I'm happy to look into these build errors if you think it's not something wrong with just my personal environment. That being said the NMS code for 1.13 can be built with: `mvn package`.