### PR TITLE
Expiremental Perf Code

### DIFF
--- a/Plugin/pom.xml
+++ b/Plugin/pom.xml
@@ -27,7 +27,7 @@
     <dependency>
       <groupId>com.comphenix.protocol</groupId>
       <artifactId>ProtocolLib-API</artifactId>
-      <version>4.0</version>
+      <version>4.4.0</version>
       <scope>provided</scope>
       <optional>true</optional>
       <exclusions>
@@ -48,6 +48,13 @@
       <type>jar</type>
       <scope>compile</scope>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>net.openhft</groupId>
+      <artifactId>zero-allocation-hashing</artifactId>
+      <version>0.8</version>
+      <type>jar</type>
+      <scope>compile</scope>
     </dependency>
     <dependency>
       <groupId>com.lishid</groupId>

--- a/Plugin/src/main/java/com/lishid/orebfuscator/obfuscation/Calculations.java
+++ b/Plugin/src/main/java/com/lishid/orebfuscator/obfuscation/Calculations.java
@@ -351,7 +351,7 @@ public class Calculations {
         chunkData.useCache = true;
         
         // Hash the chunk
-        long hash = CalculationsUtil.Hash(chunkData.data, chunkData.data.length);
+        long hash = CalculationsUtil.Hash(chunkData.data);
         // Get cache folder
         File cacheFolder = new File(ObfuscatedDataCache.getCacheFolder(), player.getWorld().getName());
         // Create cache objects

--- a/Plugin/src/main/java/com/lishid/orebfuscator/obfuscation/CalculationsUtil.java
+++ b/Plugin/src/main/java/com/lishid/orebfuscator/obfuscation/CalculationsUtil.java
@@ -16,14 +16,11 @@
 
 package com.lishid.orebfuscator.obfuscation;
 
-import java.util.zip.CRC32;
+import net.openhft.hashing.LongHashFunction;
 
 public class CalculationsUtil {
-    public static long Hash(byte[] data, int length) {
-        CRC32 crc = new CRC32();
-        crc.reset();
-        crc.update(data, 0, length);
-        return crc.getValue();
+    public static long Hash(byte[] data) {
+        return LongHashFunction.xx().hashBytes(data);
     }
 
     public static int increment(int current, int max) {

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
   <repositories>
     <repository>
       <id>dmulloy2-repo</id>
-      <url>http://repo.dmulloy2.net/content/groups/public/</url>
+      <url>http://repo.dmulloy2.net/nexus/repository/public/</url>
     </repository>
     <repository>
       <id>spigot-repo</id>


### PR DESCRIPTION
This commit includes two performance fixes that have been beneficial on our server. However, these changes on one server may not be the experience for everyone (and thus be beneficial to merge into upstream). We hope by opening this PR we can get some more people to test locally, and (maybe even on their server)!

The two changes we provide in this (besides a pom.xml change for ProtocolLib so it can build locally on a fresh box where the dependencies aren't cached) are:


1. Using Fisher-Yates Shuffle, over `Collections.shuffle`. The reason for using fisher-yates instead of `Collections.shuffle` were described originally when I was working on the original 13.1 PR, but I'll copy it here for those who don't want to go find it or didn't follow it):
> Previously we were calling out to: Collections.shuffle(Arrays.asList(...)). The problem with this is we construct an object Arrays.asList that we throw away anyway in the next GC Cycle (since it's temporary), and then we call: Collections.shuffle (which besides allocating a random object which is also GC'd next run) is with list size. If our list is over 5 (which it generally is) copies the list into an array, and performs an O(n) shuffle, then copies the array back into the list. Aka we're doing this copy/object creation for really no benefit. So I switched us to a Fisher-Yates shuffle. Which is also O(n) time like Collections.shuffle however avoids all the unnecessary copying.

All in all it means one less place we allocate objects that just get GC'd on the next GC run, while still keeping the O(N) nature of `Collections.shuffle` (so we're not taking a perf hit in time, just helping GC run faster!)

2. Using xxHash over crc32. This is the bigger change (and probably the more controversial one seeing as how it brings in an extra dependency), but can certainly help when reading/writing to the cache.

Although CRC-32 is relatively fast when compared to something like MD5, it still isn't really what we're looking for. Which is a non cryptographic high throughput hash.  For here we turn to xxHash (specifically xxHash64), which is considered one of the fastest hashes available without sacrificing quality. This statement is specifically coming from multiple SMHasher (the de-facto hash tester these days) results. [1](https://github.com/rurban/smhasher#summary) [2](http://cyan4973.github.io/xxHash/) [3](http://fastcompression.blogspot.com/2014/07/xxhash-wider-64-bits.html) [4](https://aras-p.info/blog/2016/08/09/More-Hash-Function-Tests/).

Obviously though what everyone else tests with won't map to anyone. Really what we wanna see is if it makes the experience better for a noticeable amount of users. Cause then it might be worth merging it in (or at the very least making it an option).